### PR TITLE
Tweak output format for compatibility with McIDAS

### DIFF
--- a/glmtools/grid/make_grids.py
+++ b/glmtools/grid/make_grids.py
@@ -343,7 +343,7 @@ class GLMGridder(FlashGridder):
             density_label,
             "km^2 per flash",
             # "km^2",
-            "J",
+            "nJ",
             density_label,
             density_label,
             "km^2 per group",

--- a/glmtools/io/imagery.py
+++ b/glmtools/io/imagery.py
@@ -80,7 +80,7 @@ glm_scaling = {
     'average_group_area':{'dtype':'uint16', 
         'scale_factor':1.0, 'add_offset':0.0},
     'total_energy':{'dtype':'uint16', 
-        'scale_factor':1.52597e-15, 'add_offset':0.0},
+        'scale_factor':1.52597e-6, 'add_offset':0.0,},
 }
 
 def get_goes_imager_subpoint_vars(nadir_lon):

--- a/glmtools/plot/values.py
+++ b/glmtools/plot/values.py
@@ -32,8 +32,8 @@ display_params['group_extent_density'] = {
 display_params['event_density']=display_params['group_extent_density']
 
 display_params['total_energy'] = {
-    'product_label':"GOES-16 GLM Total Energy (J)",
-    'glm_norm':LogNorm(vmin=1e-17, vmax=1e-12),
+    'product_label':"GOES-16 GLM Total Energy (nJ)",
+    'glm_norm':LogNorm(vmin=1e-8, vmax=1e-3),
     'file_tag':'total_energy',
     'format_string':'{0:3.1e}'
 }


### PR DESCRIPTION
Per a report from Unidata, McIDAS can't represent a scale factor of 1e-15 (as used for `total_energy`) in its internal 4-byte precision model. This PR changes the energy units from 'J' to 'nJ' in the metadata, allowing for a 1e-6 scale factor. To do so, the energy values are changed to nJ for all calculations within glmtools.