### PR TITLE
Add support for tree consistency check

### DIFF
--- a/glmtools/io/glm.py
+++ b/glmtools/io/glm.py
@@ -210,6 +210,8 @@ class GLMDataset(OneToManyTraversal):
                 # Make a self consistent tree by pruning the tree to just the
                 # valid flash IDs, which has the side effect of making
                 # everything else self-consistent.
+                log.warning('Fixing inconsistent parent-child IDs '
+                            'in file {0}'.format(filename))
                 flashes_with_no_groups = entity_var_stats['flash_id'][2]
                 unq_fl_id = set(list(dataset.group_parent_flash_id.data))
                 good_fl_id = list(unq_fl_id - flashes_with_no_groups)


### PR DESCRIPTION
Through the history of GLM, data files exist where the flash and group IDs do not form a self-consistent set with the corresponding group and event parent ID variables. This PR adds a method to the traversal code for checking for consistency and reporting upon it, and glm-specific support that that corrects for the problem if detected.

Example file: 
```
OR_GLM-L2-LCFA_G16_s20210821014400_e20210821015004_c20210821015014.nc
flash_id  unique count, count without children  52 5
group_id  unique count, count without children  1072 208
group_parent_flash_id unique count, count with no parent  47 0
event_parent_group_id unique count, count with no parent  993 129
```
