### PR TITLE
comment min_area references

### DIFF
--- a/glmtools/grid/make_grids.py
+++ b/glmtools/grid/make_grids.py
@@ -235,7 +235,7 @@ class GLMGridder(FlashGridder):
 
         flash_outgrids, flash_framer = self.flash_pipeline_setup()
         (init_density_grid, extent_density_grid, footprint_grid,
-            min_flash_area_grid, # flashsize_std_grid
+            #min_flash_area_grid, # flashsize_std_grid
             ) = flash_outgrids
 
         group_outgrids, group_framer = self.group_pipeline_setup()
@@ -259,7 +259,7 @@ class GLMGridder(FlashGridder):
             group_centroid_density_grid,
             group_footprint_grid,
             # groupsize_std_grid
-            min_flash_area_grid,
+            # min_flash_area_grid,
             )
         self.outgrids_3d = None
 
@@ -513,7 +513,7 @@ class GLMlutGridder(GLMGridder):
                      flash_counter=frame_count_log, do_events='time')
 
         outgrids = (init_density_grid, extent_density_grid,
-            footprint_grid, min_area_grid,
+            footprint_grid, #min_area_grid,
             )
         return outgrids, framer
 


### PR DESCRIPTION
Avoid ValueError: not enough values to unpack (expected 4, got 3)

Correct the number of arguments expected from pipelines in make_GLM_grids.py by removing references to min_flash_area_grid and min_area_grid.

```
Traceback (most recent call last):
  File "make_GLM_grids.py", line 329, in <module>
    gridder(glm_filenames, start_time, end_time, **grid_kwargs)
  File "/glade/scratch/ahijevyc/glmtools/glmtools/grid/make_grids.py", line 838, in grid_GLM_flashes
    outputs = list(map(this_proc_each_grid, subgrids))
  File "/glade/scratch/ahijevyc/glmtools/glmtools/grid/make_grids.py", line 877, in proc_each_grid
    gridder = GLMGridder(start_time, end_time, **kwargsij)
  File "/glade/u/home/ahijevyc/miniconda3/envs/glmval/lib/python3.6/site-packages/lmatools/grid/make_grids.py", line 202, in __init__
    self.pipeline_setup()
  File "/glade/scratch/ahijevyc/glmtools/glmtools/grid/make_grids.py", line 239, in pipeline_setup
    ) = flash_outgrids
ValueError: not enough values to unpack (expected 4, got 3)
```