### PR TITLE
Fixes a TypeError introduced by updating to python3.10

### DIFF
--- a/glmtools/io/glm.py
+++ b/glmtools/io/glm.py
@@ -552,8 +552,8 @@ class GLMDataset(OneToManyTraversal):
         if ellipse_rev < 0:
             log.info("Inferring lightning ellipsoid from GLM product time")
             pt = self.dataset.product_time.dt
-            date = datetime(pt.year, pt.month, pt.day,
-                            pt.hour, pt.minute, pt.second)
+            date = datetime(pt.year.values, pt.month.values, pt.day.values,
+                            pt.hour.values, pt.minute.values, pt.second.values)
             ellipse_rev = ltg_ellpse_rev(date)
         log.info("Using lightning ellipsoid rev {0}".format(ellipse_rev))
 


### PR DESCRIPTION
This patch fixes an error I encountered after updating from python3.9 to python3.10.

I've pasted the traceback below in case it proves useful.

```
Traceback (most recent call last):
  File "/data/users/nickb/cspp-geo-gridded-glm/gridded_glm/libexec/_minute_gridder.py", line 403, in <module>
    gridder_return = gridder(glm_filenames, start_time, end_time, **grid_kwargs)
  File "/data/users/nickb/cspp-geo-gridded-glm/miniforge/envs/gridded-glm-dev/lib/python3.10/site-packages/glmtools/grid/make_grids.py", line 838, in grid_GLM_flashes
    outputs = list(map(this_proc_each_grid, subgrids))
  File "/data/users/nickb/cspp-geo-gridded-glm/miniforge/envs/gridded-glm-dev/lib/python3.10/site-packages/glmtools/grid/make_grids.py", line 896, in proc_each_grid
    glm = GLMDataset(filename, ellipse_rev=ellipse_rev)
  File "/data/users/nickb/cspp-geo-gridded-glm/miniforge/envs/gridded-glm-dev/lib/python3.10/site-packages/glmtools/io/glm.py", line 236, in __init__
    self.__init_fixed_grid_data()
  File "/data/users/nickb/cspp-geo-gridded-glm/miniforge/envs/gridded-glm-dev/lib/python3.10/site-packages/glmtools/io/glm.py", line 555, in __init_fixed_grid_data
    date = datetime(pt.year, pt.month, pt.day,
TypeError: 'DataArray' object cannot be interpreted as an integer
```