### PR TITLE
add correction for time of flight to the instrument before rev 1

### DIFF
--- a/glmtools/io/glm.py
+++ b/glmtools/io/glm.py
@@ -277,11 +277,13 @@ class GLMDataset(OneToManyTraversal):
                 group_time_of_flight = (group_range/299792458) * np.timedelta64(1000000000, 'ns')
                 self.dataset.group_time_offset.data += group_time_of_flight
 
-                flash_X, flash_Y, flash_Z = geo_sys.toECEF(self.dataset.flash_lon.data, self.dataset.flash_lat.data, np.zeros_like(self.dataset.flash_lat.data))
-                flash_range = ((flash_X-satellite_X)**2 + (flash_Y-satellite_Y)**2 + (flash_Z-satellite_Z)**2)**0.5
-                flash_time_of_flight = (flash_range/299792458) * np.timedelta64(1000000000, 'ns')
-                self.dataset.flash_time_offset_of_first_event.data += flash_time_of_flight
-                self.dataset.flash_time_offset_of_last_event.data += flash_time_of_flight
+                grouped_flashes = self.dataset.groupby('event_parent_flash_id')
+                for flash_id, events in grouped_flashes:
+                    first_event_time = events.event_time_offset.data.min()
+                    last_event_time = events.event_time_offset.data.max()
+                    self.dataset.flash_time_offset_of_first_event[self.dataset.flash_id == flash_id] = first_event_time
+                    self.dataset.flash_time_offset_of_last_event[self.dataset.flash_id == flash_id] = last_event_time
+
 
 
     def __init_parent_child_data(self):

--- a/glmtools/io/glm.py
+++ b/glmtools/io/glm.py
@@ -9,6 +9,8 @@ from glmtools.io.traversal import OneToManyTraversal
 from glmtools.io.lightning_ellipse import ltg_ellps_lon_lat_to_fixed_grid
 from glmtools.io.lightning_ellipse import ltg_ellpse_rev
 
+from lmatools.coordinateSystems import GeographicSystem
+
 import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -152,7 +154,7 @@ def event_areas(flash_data):
 class GLMDataset(OneToManyTraversal):
     def __init__(self, filename, calculate_parent_child=True, ellipse_rev=-1,
                  check_area_units=True, change_energy_units=True,
-                 fix_bad_DO07_times=True, check_tree=True):
+                 fix_bad_DO07_times=True, check_tree=True, fix_bad_time_of_flight=True):
         """ filename is any data source which works with xarray.open_dataset
 
             By default, helpful additional parent-child data are calculated,
@@ -184,6 +186,9 @@ class GLMDataset(OneToManyTraversal):
             fix_bad_DO07_times: If True (default), correct for the missing
                 _Unsigned attribute for the ~month in Oct-Nov 2018 when the
                 problem was present.
+            fix_bad_time_of_flight: If True (default), correct for the the time
+                flight from the source to the satellite which was not included
+                before the first ellipsoid revision.
         """
         self.entity_ids = ['flash_id', 'group_id', 'event_id']
         self.parent_ids = ['group_parent_flash_id', 'event_parent_group_id']
@@ -250,6 +255,34 @@ class GLMDataset(OneToManyTraversal):
             # changing units.
             did_fix = self._eliminate_zero_energy()
             did_fix = self._change_energy_units()
+        if fix_bad_time_of_flight:
+            pt = self.dataset.product_time.dt
+            date = datetime(int(pt.year), int(pt.month), int(pt.day),
+                            int(pt.hour), int(pt.minute), int(pt.second))
+            check_ellipse_rev = ltg_ellpse_rev(date)
+            if check_ellipse_rev == 0:
+                geo_sys = GeographicSystem()
+                satellite_lla = (self.dataset.nominal_satellite_subpoint_lon.data.item(),
+                                 self.dataset.nominal_satellite_subpoint_lat.data.item(),
+                                 self.dataset.nominal_satellite_height.data.item()*1000)
+                satellite_X, satellite_Y, satellite_Z = geo_sys.toECEF(*satellite_lla)
+                event_X, event_Y, event_Z = geo_sys.toECEF(self.dataset.event_lon.data, self.dataset.event_lat.data, np.zeros_like(self.dataset.event_lat.data))
+                event_range = ((event_X-satellite_X)**2 + (event_Y-satellite_Y)**2 + (event_Z-satellite_Z)**2)**0.5
+                event_time_of_flight = (event_range/299792458) * np.timedelta64(1000000000, 'ns')
+                self.dataset.event_time_offset.data += event_time_of_flight
+
+
+                group_X, group_Y, group_Z = geo_sys.toECEF(self.dataset.group_lon.data, self.dataset.group_lat.data, np.zeros_like(self.dataset.group_lat.data))
+                group_range = ((group_X-satellite_X)**2 + (group_Y-satellite_Y)**2 + (group_Z-satellite_Z)**2)**0.5
+                group_time_of_flight = (group_range/299792458) * np.timedelta64(1000000000, 'ns')
+                self.dataset.group_time_offset.data += group_time_of_flight
+
+                flash_X, flash_Y, flash_Z = geo_sys.toECEF(self.dataset.flash_lon.data, self.dataset.flash_lat.data, np.zeros_like(self.dataset.flash_lat.data))
+                flash_range = ((flash_X-satellite_X)**2 + (flash_Y-satellite_Y)**2 + (flash_Z-satellite_Z)**2)**0.5
+                flash_time_of_flight = (flash_range/299792458) * np.timedelta64(1000000000, 'ns')
+                self.dataset.flash_time_offset_of_first_event.data += flash_time_of_flight
+                self.dataset.flash_time_offset_of_last_event.data += flash_time_of_flight
+
 
     def __init_parent_child_data(self):
         """ Calculate implied parameters that are useful for analyses


### PR DESCRIPTION
This PR adds an optional check to determine if the GLM dataset being used does not contain the correction for the time of flight from a particular event/group/flash to the sensor. This results in the dataset containing information of when the signal arrived at the sensor, but not when the signal was produced in the cloud. This issue is described in the GLM Product Performance Guide as issue 3.4.2, which was fixed in ADR 333 (October 18 2018).

When reading in a GLM dataset, the date is checked to see if it was produced before the fix was implemented, calculates the time of flight to each event/group/flash's location to the satellite, and then adds this value to the event_time_offset, event_group_offset, and flash_time_offset_of_first_event and flash_time_offset_of_last_event. The following assumptions are made:
- the height above the WGS84 ellipsoid of each event/group is assumed to be negligible compared to the height of the satellite
- the satellite is located precisely above its expected subpoint and precisely at its height
- the speed of light is precisely 299792458 m/s

This should work well enough in most cases, but the user can override this behavior by specifying `fix_bad_time_of_flight=False` in the call to GLMDataset.