### PR TITLE
Fix nominal_satellite_subpoint_lon(dim_0) in gridded output

### DIFF
--- a/glmtools/io/imagery.py
+++ b/glmtools/io/imagery.py
@@ -108,7 +108,7 @@ def get_goes_imager_subpoint_vars(nadir_lon):
     sublat = xr.DataArray(0.0, name='nominal_satellite_subpoint_lat',
                           attrs=sublat_meta)
     sublat.encoding = sublat_enc
-    sublon = xr.DataArray(nadir_lon, name='nominal_satellite_subpoint_lon',
+    sublon = xr.DataArray(nadir_lon[0], name='nominal_satellite_subpoint_lon',
                           attrs=sublon_meta)
     sublon.encoding = sublon_enc
     return sublon, sublat


### PR DESCRIPTION
Gridded output netcdf files (for example as created by the make_GLM_grids.py example) contains output that looks like this:

	double nominal_satellite_subpoint_lat ;
		nominal_satellite_subpoint_lat:_FillValue = -999. ;
		nominal_satellite_subpoint_lat:long_name = "nominal satellite subpoint latitude (platform latitude)" ;
		nominal_satellite_subpoint_lat:standard_name = "latitude" ;
		nominal_satellite_subpoint_lat:units = "degrees_north" ;
	double nominal_satellite_subpoint_lon(dim_0) ;
		nominal_satellite_subpoint_lon:_FillValue = -999. ;
		nominal_satellite_subpoint_lon:long_name = "nominal satellite subpoint longitude (platform longitude)" ;
		nominal_satellite_subpoint_lon:standard_name = "longitude" ;
		nominal_satellite_subpoint_lon:units = "degrees_east" ;

I'm assuming that the (dim_0) is unintentional. This commit from nbearson should fix it.